### PR TITLE
Konflux 4267

### DIFF
--- a/.tekton/odh-modelmesh-v2-13-push.yaml
+++ b/.tekton/odh-modelmesh-v2-13-push.yaml
@@ -271,6 +271,9 @@ spec:
       runAfter:
         - clone-pnc-cli-config-repository
       taskSpec:
+        results:
+          - description: The file containing the list of pnc built artifacts to be later installed inside the container build
+            name: pnc-file-list
         steps:
           - name: run-pnc-build
             image: quay.io/redhat-user-workloads/konflux-jbs-pnc-tenant/pnc/pnc-cli:64de07fb16f9a31799f1e020df9f4fc1015212dc
@@ -279,48 +282,44 @@ spec:
                 valueFrom:
                   secretKeyRef:
                     name: pnc-secret
-                    key: svc.account.username    
+                    key: svc.account.username
               - name: SSO_SERVICE_ACCOUNT_CLIENT_SECRET
                 valueFrom:
                   secretKeyRef:
-                    name: pnc-secret            
-                    key: svc.account.password      
+                    name: pnc-secret
+                    key: svc.account.password
               - name: PNC_PROFILE
                 valueFrom:
                   secretKeyRef:
-                    name: pnc-secret               
-                    key: pnc.profile               
-
-              #- name: svc-account-name
-                #value: $(params.svc-account-name)
-              #- name: svc-account-secret
-                #valueFrom:
-                  #secretKeyRef:
-                   # name: $(params.svc-account-name)
-                    #key: rhoai-pnc-oidc-sa
-              #- name: SSO_SERVICE_ACCOUNT_NAME
-                #value: $(params.svc-account-name)
-              #- name: SSO_SERVICE_ACCOUNT_CLIENT_SECRET
-                #valueFrom:
-                  #secretKeyRef:
-                    #name: $(params.svc-account-name)  
-                    #key: rhoai-pnc-oidc-sa
-              
+                    name: pnc-secret
+                    key: pnc.profile
               
             script: |
               #!/bin/bash
               set -e
-              set -x
-              
-              echo "Starting a PNC build..."
 
-              echo -n "\n=== Build config ==="
+              echo -e "\n=== Build config ==="
               cat /workspace/output/build-config/$(params.build-config-path)
-
               cp /workspace/output/build-config/$(params.build-config-path) /workspace/output
+              echo -e "===================="
+
+              echo -e "\nReplacing credentials in the CLI config ..."
               envsubst '${SSO_SERVICE_ACCOUNT_NAME} ${SSO_SERVICE_ACCOUNT_CLIENT_SECRET}' < /workspace/output/cli-config/konflux/configs/pnc_cli/config.yaml > /workspace/output/config.yaml
+
+              echo -e "\nStarting the PNC build ..."
+              PNC_CLI_OUTPUT_FILE="/workspace/output/pnc-cli-run-output.json"
+              java -jar /home/jboss/bacon.jar pig run --mode=FORCE --downloadAttempts=3 /workspace/output -p /workspace/output --profile ${PNC_PROFILE} --jsonOutput > $PNC_CLI_OUTPUT_FILE
+
+              echo -e "\nFinished the PNC build!"
+              echo -e "\n=== PNC build output ==="
+              cat $PNC_CLI_OUTPUT_FILE
+              echo -e "===================="
+
+              echo -e "\nGetting the list of built files (to be used later in the container build) ..."
+              jq '[.builds[].builtArtifacts[]?.downloadUrl ]' "$PNC_CLI_OUTPUT_FILE" > "$(results.pnc-file-list.path)"
               
-              java -jar /home/jboss/bacon.jar pig run --mode=FORCE --downloadAttempts=3 /workspace/output -p /workspace/output --profile ${PNC_PROFILE} --jsonOutput
+              cat  $(results.pnc-file-list.path)
+
       workspaces:
       - name: output
         workspace: workspace
@@ -329,7 +328,7 @@ spec:
       - name: input
         value: $(params.prefetch-input)
       runAfter:
-      - clone-repository
+      - pnc-cli-build
       taskRef:
         params:
         - name: name
@@ -369,6 +368,7 @@ spec:
         value: $(tasks.clone-repository.results.commit)
       - name: BUILD_ARGS
         value:
+        - PNC_FILES_JSON=$(tasks.pnc-cli-build.results.pnc-file-list)
         - $(params.build-args[*])
       - name: BUILD_ARGS_FILE
         value: $(params.build-args-file)


### PR DESCRIPTION
- Add the list of built files from PNC into a result; use the result as an argument inside the container build task; execute the prefetch-dependencies task after the pnc-cli-build task
- Alter the Dockerfile to use the build argument with the list of PNC built artifacts; filter the ZIP files from the list and unzip them in the stage build; add the version file to etc as done previously, using the content from the ZIP
